### PR TITLE
Remove url attribute define as required 

### DIFF
--- a/swagger.yaml
+++ b/swagger.yaml
@@ -364,7 +364,6 @@ components:
         - id
         - type
         - mimeType
-        - url
       properties:
         id:
           type: string


### PR DESCRIPTION
The "url" attribute is define as required in the "Photo" object but it hasn't this attribute.  